### PR TITLE
feat(redeem): Batch redeem cancellation

### DIFF
--- a/src/redeem.ts
+++ b/src/redeem.ts
@@ -150,10 +150,6 @@ export class Redeem {
             console.log(`adding ${redeemId.toHuman()}`);
             this.expiredRedeemRequests.push(redeemId)
         });
-        // Wait for any old expired redeems to be fetched
-        // so as to cancel the request (banning the vault).
-        // This will prevent requesting redeem from that vault.
-        await sleep(10000);
         await this.cancelExpiredRedeems();
         console.log(`[${new Date().toLocaleString()}] -----Performing heartbeat redeems-----`);
         const vaults = _.shuffle(await this.polkaBtc.vaults.list());

--- a/src/redeem.ts
+++ b/src/redeem.ts
@@ -1,4 +1,4 @@
-import { PolkaBTCAPI, btcToSat, stripHexPrefix, BitcoinCoreClient } from "@interlay/polkabtc";
+import { PolkaBTCAPI, btcToSat, stripHexPrefix, BitcoinCoreClient, sleep } from "@interlay/polkabtc";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { H256 } from "@polkadot/types/interfaces";
 import * as polkabtcStats from '@interlay/polkabtc-stats';
@@ -14,6 +14,7 @@ export class Redeem {
     issue: Issue;
     private redeemDustValue: Big | undefined;
     polkaBtc: PolkaBTCAPI;
+    expiredRedeemRequests: H256[] = [];
     constructor(polkaBtc: PolkaBTCAPI, private issueTopUpAmount = new Big(1)) {
         this.issue = new Issue(polkaBtc);
         this.polkaBtc = polkaBtc;
@@ -143,6 +144,17 @@ export class Redeem {
             console.log("Parachain not connected");
             return;
         }
+        console.log(`[${new Date().toLocaleString()}] -----Cancelling expired redeems-----`);
+        const botAccountId = this.polkaBtc.api.createType("AccountId", account.address);
+        this.polkaBtc.redeem.subscribeToRedeemExpiry(botAccountId, (redeemId: H256) => {
+            console.log(`adding ${redeemId.toHuman()}`);
+            this.expiredRedeemRequests.push(redeemId)
+        });
+        // Wait for any old expired redeems to be fetched
+        // so as to cancel the request (banning the vault).
+        // This will prevent requesting redeem from that vault.
+        await sleep(10000);
+        await this.cancelExpiredRedeems();
         console.log(`[${new Date().toLocaleString()}] -----Performing heartbeat redeems-----`);
         const vaults = _.shuffle(await this.polkaBtc.vaults.list());
         const bitcoinCoreClient = new BitcoinCoreClient(
@@ -161,8 +173,12 @@ export class Redeem {
         );
         const amountToRedeem = await this.getMinRedeemableAmount();
         for (const vault of vaults) {
-            if (vault.issued_tokens.gte(new BN(btcToSat(amountToRedeem.toString())))) {
-                try {
+            try {
+                const currentBlock = await this.polkaBtc.system.getCurrentBlockNumber();
+                if (vault.banned_until.isSome && vault.banned_until.unwrap().toNumber() >= currentBlock) {
+                    continue;
+                }
+                if (vault.issued_tokens.gte(new BN(btcToSat(amountToRedeem.toString())))) {
                     console.log(`[${new Date().toLocaleString()}] Redeeming ${btcToSat(amountToRedeem.toString())} out of ${vault.issued_tokens} InterSatoshi from ${vault.id.toString()}`);
                     const requestResult = await this.polkaBtc.redeem.request(
                         amountToRedeem,
@@ -170,10 +186,6 @@ export class Redeem {
                         vault.id
                     ).catch(error => { throw new Error(error) });
                     const redeemRequestId = requestResult.id.toString();
-
-                    // Subscribe to redeem expiry
-                    const botAccountId = this.polkaBtc.api.createType("AccountId", account.address);
-                    this.polkaBtc.redeem.subscribeToRedeemExpiry(botAccountId, this.retryRedeem);
                     
                     // Wait at most `timeoutMinutes` minutes to receive the BTC transaction with the
                     // redeemed funds.
@@ -181,22 +193,26 @@ export class Redeem {
                     await this.polkaBtc.electrsAPI.waitForOpreturn(opreturnData, timeoutMinutes * 60000, 5000)
                         .catch(_ => { throw new Error(`Redeem request was not executed, timeout expired`) });
                     this.vaultHeartbeats.set(vault.id.toString(), Date.now());
-                } catch (error) {
-                    console.log(`Error: ${error}`);
                 }
-
+            } catch (error) {
+                console.log(`Error: ${error}`);
             }
         }
     }
 
-    async retryRedeem(redeemId: H256): Promise<void> {
-        try {
-            console.log(`[${new Date().toLocaleString()}] Retrying redeem with id ${redeemId.toHuman()}...`);
-            // Cancel redeem request and receive DOT compensation
-            await this.polkaBtc.redeem.cancel(redeemId, false);
-        } catch (error) {
-            console.log(`Error: ${error}`);
+    async cancelExpiredRedeems(): Promise<void> {
+        const remainingExpiredRequests: H256[] = [];
+        for(const redeemId of this.expiredRedeemRequests) {
+            try {
+                console.log(`[${new Date().toLocaleString()}] Retrying redeem with id ${redeemId.toHuman()}...`);
+                // Cancel redeem request and receive DOT compensation
+                await this.polkaBtc.redeem.cancel(redeemId, false);
+            } catch (error) {
+                remainingExpiredRequests.push(redeemId);
+                console.log(`Error cancelling redeem ${redeemId.toHuman()}... : ${error}`);
+            }
         }
+        this.expiredRedeemRequests = remainingExpiredRequests;
     }
 
     /**


### PR DESCRIPTION
The polkadot-js callback does not `await`, which means a quick succession of callbacks may result in tx priority errors. This PR avoids that issue.
Moreover, banned vaults are now skipped when redeeming.

Some notes on upcoming work:
- All bot redeem requests currently time out (take > 2 mins) to be completed.
- This means the bot cannot reliably determine active redeem vaults
- Up and coming is a lib extension to subscribe to redeem cancellations using the same core functionality as the subscription to redeem expiry. I'm hoping this, coupled with the ability to sudo set the block height, will allow for speedy testing of redeem execution/cancellation in the lib pipeline
- The above would enable the bot to correctly persist active vaults to the stats DB